### PR TITLE
Fix cumulative render jank

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Chrome",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src",
+      "sourceMapPathOverrides": {
+        "webpack:///src/*": "${webRoot}/*"
+      }
+    }
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,8 @@
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css' rel='stylesheet' />
     <link href='https://webfonts.artsy.net/all-webfonts.css' rel='stylesheet' />
 
+    <!-- Refresh page every 8 hours, so as to prevent rendering weirdness that creeps in after several days -->
+    <meta http-equiv="refresh" content="28800">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -11,7 +11,7 @@ export class Progress extends React.Component<Props> {
     return (
       <Dots>
         {cities.map((_city, i) => (
-          <Dot selected={i === this.props.index} />
+          <Dot key={i} selected={i === this.props.index} />
         ))}
       </Dots>
     )

--- a/src/lib/geojson.ts
+++ b/src/lib/geojson.ts
@@ -1,8 +1,10 @@
 import { CityResponse } from './metaphysics'
 
 export const cityResultsToGeoJson = (data: CityResponse) => {
-  const fairs = data.city.fairs.edges.map(edge => edge.node)
-  const fairFeatures = fairs.map(fair => ({
+  const fairsWithLocations = data.city.fairs.edges
+    .filter(edge => edge.node.location)
+    .map(edge => edge.node)
+  const fairFeatures = fairsWithLocations.map(fair => ({
     type: 'Feature',
     properties: {
       type: 'fair'
@@ -16,8 +18,10 @@ export const cityResultsToGeoJson = (data: CityResponse) => {
     }
   }))
 
-  const shows = data.city.shows.edges.map(edge => edge.node)
-  const showFeatures = shows.map(show => ({
+  const showsWithLocations = data.city.shows.edges
+    .filter(edge => edge.node.location)
+    .map(edge => edge.node)
+  const showFeatures = showsWithLocations.map(show => ({
     type: 'Feature',
     properties: {
       type: 'show'


### PR DESCRIPTION
Fixes the issue where rendering starts to degrade (and eventually crash the browser) after several days of running continuously.

Instead let's just reload the page every 8 hours.